### PR TITLE
#29 이슈 대응 - 다른 채팅방 클릭 시 새롭게 구성되도록 수정

### DIFF
--- a/src/components/chatRoom/SidebarContent.js
+++ b/src/components/chatRoom/SidebarContent.js
@@ -223,9 +223,6 @@ function SidebarContent(prop) {
                                     primary={value.postTitle}
                                     secondary={`${value.opponentIdentity} 님과의 채팅방`}
                                 />
-                                <Label color="primary">
-                                    <b>2</b>
-                                </Label>
                             </ListItemWrapper>
                         ))}
                     </List>
@@ -257,9 +254,6 @@ function SidebarContent(prop) {
                                         primary={value.postTitle}
                                         secondary={`${value.opponentIdentity} 님과의 채팅방`}
                                     />
-                                    <Label color="primary">
-                                        <b>2</b>
-                                    </Label>
                                 </ListItemWrapper>
                             ))}
                     </List>


### PR DESCRIPTION
# 수정작업 정리
## 불필요 라벨 제거
- 미구현된 알림 라벨을 제거
![image](https://user-images.githubusercontent.com/15000594/137905411-e8092609-5f63-4d9b-90de-e5648b8c8456.png)

## 채팅방 재구성 처리되도록 수정
- 현재 선택한 채팅방의 id를 식별할 수 있도록 state 구성
- 현재 로직에서 roomId가 변경된 경우에도 init (초기상태) 처리되도록 로직 보완
![image](https://user-images.githubusercontent.com/15000594/137905560-594e69c1-3f4a-4387-b7b5-246a3c9270b8.png)
![image](https://user-images.githubusercontent.com/15000594/137905593-de21310d-6ef8-4990-a779-c7000706d66d.png)
![image](https://user-images.githubusercontent.com/15000594/137905628-bbf874d4-4cce-409d-af20-a6b6d4def213.png)

